### PR TITLE
0.5.4 Main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+*.patch text eol=lf
+*.diff text eol=lf
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf
+
+.gitattributes linguist-generated=true
+.gitignore linguist-generated=true
+LICENSE.txt linguist-generated=true
+README.md linguist-generated=true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Anaconda Inc - Anaconda Recipes
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# About py-partiql-parser
+===========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/AnacondaRecipes/py-partiql-parser-feedstock/blob/main/LICENSE)
+
+Home: None
+
+Package license: MIT
+
+Summary: Pure Python PartiQL Parser
+
+Installing py-partiql-parser
+================
+
+`py-partiql-parser` can be installed with:
+
+```
+conda install py-partiql-parser
+```

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,16 +23,12 @@ requirements:
     - python
 
 test:
-  source_files:
-    - tests
   imports:
     - py_partiql_parser
   commands:
     - pip check
-    - pytest -v tests
   requires:
     - pip
-    - pytest
 
 about:
   home: https://github.com/getmoto/py-partiql-parser/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - py_partiql_parser
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/getmoto/py-partiql-parser/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "py-partiql-parser" %}
+{% set version = "0.5.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/py_partiql_parser-{{ version }}.tar.gz
+  sha256: 72e043919538fa63edae72fb59afc7e3fd93adbde656718a7d2b4666f23dd114
+
+build:
+  skip: true # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - hatchling
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - py_partiql_parser
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/getmoto/py-partiql-parser/
+  summary: Pure Python PartiQL Parser
+  description: |
+    A tokenizer/parser/executor for the PartiQL-language, in Python.
+  dev_url: https://github.com/getmoto/py-partiql-parser/
+  doc_url: https://github.com/getmoto/py-partiql-parser/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - JamesRobertsonGames


### PR DESCRIPTION
[py-partiql-parser-feedstock](https://github.com/AnacondaRecipes/py-partiql-parser-feedstock) 0.5.4 

**Destination channel:** defaults

### Links

- [PKG-4577](https://anaconda.atlassian.net/browse/PKG-4577) 
- [Upstream repository](https://github.com/getmoto/py-partiql-parser)
- [Upstream changelog/diff](https://github.com/getmoto/py-partiql-parser/releases/tag/0.5.4)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/moto-feedstock/pull/36

### Explanation of changes:
- new feedstock


[PKG-4577]: https://anaconda.atlassian.net/browse/PKG-4577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ